### PR TITLE
Fix pixel grid becoming thicker on larger canvases

### DIFF
--- a/app/src/main/java/com/realtomjoney/pyxlmoose/customviews/mycanvasview/MyCanvasView.kt
+++ b/app/src/main/java/com/realtomjoney/pyxlmoose/customviews/mycanvasview/MyCanvasView.kt
@@ -76,7 +76,7 @@ class MyCanvasView (context: Context, var spanCount: Double) : View(context) {
         val gridPaint = Paint().apply {
             style = Paint.Style.FILL
             color = Color.parseColor("#ededed")
-            strokeWidth = 2.5f
+            strokeWidth = (scale / 8).toFloat()
             isAntiAlias = false
         }
 


### PR DESCRIPTION
There was an issue in which the pixel grid's thickness was behaving strange in canvases with larger `spanCount` values. 

This bug has been fixed.